### PR TITLE
Add CMS CMS Final Remark

### DIFF
--- a/lib/jvm_gclog.rb
+++ b/lib/jvm_gclog.rb
@@ -126,6 +126,11 @@ class JVMGCLog
       record.update(match_fields_to_hash(m))
       record["type"] = "FullGC"
 
+    when /\[GC \(CMS Final Remark\).+ (?<gctime>[\d\.]+) secs\]/
+      m = Regexp.last_match
+      record.update(match_fields_to_hash(m))
+      record["type"] = "CMS-Final-Remark"
+
     when /^\[(?<type>[A-Za-z\-]+)(: (?<time_cpu>[\d\.]+)\/(?<time_wall>[\d\.]+) secs)?\]/
       m = Regexp.last_match
       record.update(match_fields_to_hash(m))


### PR DESCRIPTION
# 変更内容

gc.logの`GC CMS Final Remark`にマッチする変更

```
Aug 31 07:19:09 bc2f160ac4a6 digdag_jvm_gc: env:local   container:digdag        container_id:d4aa04fc9a81       message:2017-08-31T07:19:09.706+0000: 2.928: [GC (CMS Final Remark) [YG occupancy: 2448 K (19008 K)]2017-08-31T07:19:09.706+0000: 2.928: [Rescan (parallel) , 0.0012976 secs]2017-08-31T07:19:09.707+0000: 2.929: [weak refs processing, 0.0000585 secs]2017-08-31T07:19:09.707+0000: 2.929: [class unloading, 0.0075507 secs]2017-08-31T07:19:09.715+0000: 2.937: [scrub symbol table, 0.0040004 secs]2017-08-31T07:19:09.719+0000: 2.941: [scrub string table, 0.0006747 secs][1 CMS-remark: 11602K(42368K)] 14051K(61376K), 0.0143929 secs] [Times: user=0.02 sys=0.00, real=0.01 secs] ```
